### PR TITLE
Fix crash when loaded on server, add config options, bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ org.gradle.daemon=false
 name=LegendaryTooltips
 group=com.anthonyhilyard.legendarytooltips
 author=anthonyhilyard
-version=1.1.8
+version=1.1.9
 mcVersion=1.12.2
 forgeVersion=14.23.5.2860

--- a/src/main/java/com/anthonyhilyard/legendarytooltips/LegendaryTooltips.java
+++ b/src/main/java/com/anthonyhilyard/legendarytooltips/LegendaryTooltips.java
@@ -16,10 +16,11 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import com.anthonyhilyard.legendarytooltips.render.TooltipDecor;
 import com.anthonyhilyard.legendarytooltips.util.ItemColor;
 
+import net.minecraftforge.fml.relauncher.Side;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-@Mod(modid=Loader.MODID, name=Loader.MODNAME, version=Loader.MODVERSION, acceptedMinecraftVersions = "[1.12.2]")
-@EventBusSubscriber(modid = Loader.MODID)
+@Mod(modid=Loader.MODID, name=Loader.MODNAME, version=Loader.MODVERSION, acceptedMinecraftVersions = "[1.12.2]", clientSideOnly = true)
+@EventBusSubscriber(modid = Loader.MODID, value = Side.CLIENT)
 public class LegendaryTooltips
 {
 	@Instance(Loader.MODID)
@@ -90,7 +91,8 @@ public class LegendaryTooltips
 	@SuppressWarnings({"generic", "null"})
 	public static void onRenderTick(TickEvent.RenderTickEvent event)
 	{
-		TooltipDecor.updateTimer();
+		//Only tick timer once per tick, 2 phases
+		if(event.phase == TickEvent.Phase.END) TooltipDecor.updateTimer();
 
 		Minecraft mc = Minecraft.getMinecraft();
 		if (mc.currentScreen != null)
@@ -106,6 +108,7 @@ public class LegendaryTooltips
 						lastTooltipItem = ((GuiContainer)mc.currentScreen).getSlotUnderMouse().getStack();
 					}
 				}
+				else TooltipDecor.resetTimer();//Required, otherwise mousing over an empty slot or no slot then back does not reset the timer
 			}
 		}
 	}

--- a/src/main/java/com/anthonyhilyard/legendarytooltips/LegendaryTooltipsConfig.java
+++ b/src/main/java/com/anthonyhilyard/legendarytooltips/LegendaryTooltipsConfig.java
@@ -23,8 +23,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import com.anthonyhilyard.legendarytooltips.util.Selectors;
 import com.anthonyhilyard.legendarytooltips.util.TextColor;
+import net.minecraftforge.fml.relauncher.Side;
 
-@EventBusSubscriber(modid = Loader.MODID)
+@EventBusSubscriber(modid = Loader.MODID, value = Side.CLIENT)
 public class LegendaryTooltipsConfig extends Configuration
 {
 	public static LegendaryTooltipsConfig INSTANCE;
@@ -37,6 +38,10 @@ public class LegendaryTooltipsConfig extends Configuration
 	public boolean bordersMatchRarity;
 	public boolean tooltipShadow;
 	public boolean shineEffect;
+
+	public boolean shineRepeat;
+	public boolean shineSync;
+	public int shineTicks;
 
 	private final List<List<String>> itemSelectors = new ArrayList<List<String>>(LegendaryTooltips.NUM_FRAMES);
 
@@ -120,6 +125,10 @@ public class LegendaryTooltipsConfig extends Configuration
 		bordersMatchRarity = getBoolean("borders_match_rarity", "visual_options", true, "If enabled, tooltip border colors will match item rarity colors (except for custom borders).");
 		tooltipShadow = getBoolean("tooltip_shadow", "visual_options", true, "If enabled, tooltips will display a drop shadow.");
 		shineEffect = getBoolean("shine_effect", "visual_options", true, "If enabled, items showing a custom border will have a special shine effect when hovered over.");
+		shineRepeat = getBoolean("shine_repeat", "visual_options", false, "Whether or not to repeat the shine effect, or to only play it once.");
+		shineSync = getBoolean("shine_sync", "visual_options", false, "Whether or not to sync horizontal and vertical shine, or delay vertical shine.");
+		shineTicks = getInt("shine_ticks", "visual_options", 50, 50, 800, "The speed at which to player the shine effect, higher value is slower.");
+
 
 		// Level 0 by default applies to epic and rare items.
 		itemSelectors.add(Arrays.asList(getStringList("level0_entries", "definitions", new String[]{"!epic", "!rare"}, "")));

--- a/src/main/java/com/anthonyhilyard/legendarytooltips/Loader.java
+++ b/src/main/java/com/anthonyhilyard/legendarytooltips/Loader.java
@@ -7,7 +7,7 @@ public class Loader
 {
 	public static final String MODID = "legendarytooltips";
 	public static final String MODNAME = "Legendary Tooltips";
-	public static final String MODVERSION = "1.1.8";
+	public static final String MODVERSION = "1.1.9";
 	public static final Logger LOGGER = LogManager.getLogger(MODID);
 
 	public Loader()

--- a/src/main/java/com/anthonyhilyard/legendarytooltips/render/TooltipDecor.java
+++ b/src/main/java/com/anthonyhilyard/legendarytooltips/render/TooltipDecor.java
@@ -57,7 +57,7 @@ public class TooltipDecor
 
 	public static void resetTimer()
 	{
-		shineTimer = 50;
+		shineTimer = LegendaryTooltipsConfig.INSTANCE.shineTicks;
 	}
 	
 	public static void drawShadow(int x, int y, int width, int height)
@@ -151,11 +151,14 @@ public class TooltipDecor
 
 		if (LegendaryTooltipsConfig.INSTANCE.shineEffect)
 		{
+			//Use config-defined value, replace hardcoded values with percents to match original at 50
+			int maxTick = LegendaryTooltipsConfig.INSTANCE.shineTicks;
 			// Draw shiny effect here.
-			if (shineTimer >= 10 && shineTimer <= 40)
+			if (shineTimer >= (maxTick * 0.2F) && shineTimer <= (maxTick * 0.8F))
 			{
-				float interval = MathHelper.clamp((float)(shineTimer - 10) / 20.0f, 0.0f, 1.0f);
+				float interval = MathHelper.clamp(((float)shineTimer - ((float)maxTick * 0.2F)) / ((float)maxTick * 0.6F), 0.0f, 1.0f);
 				int alpha = (int)(0x99 * interval) << 24;
+
 
 				int horizontalMin = x - 3;
 				int horizontalMax = x + width + 3;
@@ -164,17 +167,37 @@ public class TooltipDecor
 				GuiHelper.drawGradientRectHorizontal(402, Math.max(horizontalInterval, horizontalMin), y - 3, Math.min(horizontalInterval + 36, horizontalMax), y - 3 + 1, 0x00FFFFFF | alpha, 0x00FFFFFF);
 			}
 
-			if (shineTimer <= 20)
-			{
-				float interval = MathHelper.clamp((float)shineTimer / 20.0f, 0.0f, 1.0f);
-				int alpha = (int)(0x55 * interval) << 24;
+			if(LegendaryTooltipsConfig.INSTANCE.shineSync) {
+				//Sync vertical interval to horizontal
+				if (shineTimer >= (maxTick * 0.2F) && shineTimer <= (maxTick * 0.8F))
+				{
+					float interval = MathHelper.clamp(((float)shineTimer - ((float)maxTick * 0.2F)) / ((float)maxTick * 0.6F), 0.0f, 1.0f);
+					int alpha = (int)(0x55 * interval) << 24;
 
-				int verticalMin = y - 3 + 1;
-				int verticalMax = y + height + 3 - 1;
-				int verticalInterval = (int)lerp(interval * interval, verticalMax, verticalMin);
-				GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval - 12, verticalMin), x - 3 + 1, Math.min(verticalInterval, verticalMax), 0x00FFFFFF, 0x00FFFFFF | alpha);
-				GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval, verticalMin), x - 3 + 1, Math.min(verticalInterval + 12, verticalMax), 0x00FFFFFF | alpha, 0x00FFFFFF);
+					int verticalMin = y - 3 + 1;
+					int verticalMax = y + height + 3 - 1;
+					int verticalInterval = (int)lerp(interval * interval, verticalMax, verticalMin);
+					GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval - 12, verticalMin), x - 3 + 1, Math.min(verticalInterval, verticalMax), 0x00FFFFFF, 0x00FFFFFF | alpha);
+					GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval, verticalMin), x - 3 + 1, Math.min(verticalInterval + 12, verticalMax), 0x00FFFFFF | alpha, 0x00FFFFFF);
+				}
 			}
+			else {
+				//Don't sync vertical and horizontal, play later as original
+				if (shineTimer <= (maxTick * 0.4F))
+				{
+					float interval = MathHelper.clamp((float)shineTimer / ((float)maxTick * 0.4F), 0.0f, 1.0f);
+					int alpha = (int)(0x55 * interval) << 24;
+
+					int verticalMin = y - 3 + 1;
+					int verticalMax = y + height + 3 - 1;
+					int verticalInterval = (int)lerp(interval * interval, verticalMax, verticalMin);
+					GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval - 12, verticalMin), x - 3 + 1, Math.min(verticalInterval, verticalMax), 0x00FFFFFF, 0x00FFFFFF | alpha);
+					GuiUtils.drawGradientRect(402, x - 3, Math.max(verticalInterval, verticalMin), x - 3 + 1, Math.min(verticalInterval + 12, verticalMax), 0x00FFFFFF | alpha, 0x00FFFFFF);
+				}
+			}
+
+			//Reset timer to repeat shine after it is done playing if config option is enabled
+			if(shineTimer <= 0 && LegendaryTooltipsConfig.INSTANCE.shineRepeat) TooltipDecor.resetTimer();
 		}
 
 		// Here we will overlay a 6-patch border over the tooltip to make it look fancy.


### PR DESCRIPTION
Fix crash when this mod is loaded server-side.
Fix shine update timer being ticked twice for every tick. 
Fix shine update timer only being reset when mousing over a different item, and not empty slots. 
Added config option for repeating the shine effect, instead of only playing it once. 
Added config option for syncing vertical and horizontal shine, instead of delaying vertical. 
Added config option for changing the speed of the shine effect, instead of a hardcoded value. 
Bump version to 1.1.9

Default settings should match what they already are.